### PR TITLE
perf: Cap pixel ratio to 2x for better performance on high-DPI displays

### DIFF
--- a/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
+++ b/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
@@ -258,7 +258,13 @@ export function SceneCanvasWithControls() {
     // ===== RENDERER =====
     const renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setSize(width, height);
-    renderer.setPixelRatio(window.devicePixelRatio);
+
+    // Cap pixel ratio to 2x for better performance
+    // Ratio 3x costs 2.25x more (9 vs 4 pixels) with minimal visual improvement
+    const pixelRatio = Math.min(window.devicePixelRatio, 2);
+    renderer.setPixelRatio(pixelRatio);
+    console.log(`[Renderer] Device pixel ratio: ${window.devicePixelRatio}x, using: ${pixelRatio}x`);
+
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;


### PR DESCRIPTION
- Limit pixel ratio to max 2x instead of using device native ratio
- Prevents 3x ratio (9 pixels per point) on Retina displays
- Expected 2-3x FPS improvement on Mac and high-DPI screens
- Minimal visual difference between 2x and 3x
- Benefits all platforms with 4K/5K displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)