### PR TITLE
perf: Force high-performance GPU on dual-GPU systems

### DIFF
--- a/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
+++ b/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
@@ -256,13 +256,17 @@ export function SceneCanvasWithControls() {
     camera.lookAt(0, 1, 0);
 
     // ===== RENDERER =====
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: "high-performance" // Force dedicated GPU on dual-GPU systems (Mac, laptops)
+    });
     renderer.setSize(width, height);
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1.7;
+    console.log('[Renderer] GPU power preference: high-performance (dedicated GPU if available)');
     container.appendChild(renderer.domElement);
 
     // ===== CONTROLS =====


### PR DESCRIPTION
- Add powerPreference: "high-performance" to WebGLRenderer
- Forces dedicated GPU (AMD/NVIDIA) instead of integrated GPU (Intel)
- Expected 50-200% FPS improvement on MacBooks with dual GPU
- No impact on single-GPU systems
- Increases battery usage but provides better 3D performance
