### PR TITLE
perf: Adaptive bloom resolution based on pixel ratio

### DIFF
--- a/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
+++ b/src/components/V20.001_xstate/xstate-v5/components/SceneCanvasWithControls.tsx
@@ -299,14 +299,24 @@ export function SceneCanvasWithControls() {
     const renderPass = new RenderPass(scene, camera);
     composer.addPass(renderPass);
 
+    // Adaptive bloom resolution based on pixel ratio
+    // High-DPI screens (Retina, 4K) use reduced bloom resolution for better performance
+    // Standard screens keep full resolution for maximum quality
+    const pixelRatio = window.devicePixelRatio;
+    const bloomResolutionScale = pixelRatio > 1 ? 0.5 : 1.0;
+    const bloomWidth = width * bloomResolutionScale;
+    const bloomHeight = height * bloomResolutionScale;
+
     const bloomPass = new UnrealBloomPass(
-      new THREE.Vector2(width, height),
+      new THREE.Vector2(bloomWidth, bloomHeight),
       0.40, // strength
       0.4,  // radius
       0.15  // threshold
     );
     bloomPass.enabled = true;
     composer.addPass(bloomPass);
+
+    console.log(`[Bloom] Resolution: ${bloomWidth}×${bloomHeight} (scale: ${bloomResolutionScale.toFixed(1)}x, pixel ratio: ${pixelRatio}x)`);
 
     // ===== CONNECT TO XSTATE MACHINES =====
 


### PR DESCRIPTION
- Reduce bloom resolution by 50% on high-DPI screens (pixel ratio > 1)
- Keep full resolution on standard screens (pixel ratio = 1)
- Expected 20-30% FPS improvement on Retina/4K displays
- Minimal visual impact (bloom is blurry by nature)
- PC 1920x1080: bloom stays at 1920x1080 (full quality)
- Mac Retina 2x: bloom at 960x540 (optimized, 4x fewer pixels)
